### PR TITLE
fix variable name and factor level ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ logs
 .lintr
 .snakemake
 *__pycache__*
+.DS_Store
+workflow/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.3] - 2022-11-21
+
+### Fixed
+- fix bug in script `filter_genes_and_cells.R` that resulted in colour discrepancy between legend and plot in `{sample}.visualize_filtered_cells.png` in rare cases.
+
 ## [2.0.2] - 2022-08-31
 
 ### Changed

--- a/workflow/scripts/filter_genes_and_cells.R
+++ b/workflow/scripts/filter_genes_and_cells.R
@@ -375,10 +375,9 @@ cell_info$col[cell_info$nodg_lower_threshold] <- "cyan"
 both_filters <- rowSums(cell_info[, c("is_mt_outlier", "mt_higher_threshold")]) > 0 & rowSums(cell_info[, c("is_nodg_outlier", "nodg_lower_threshold")]) > 0
 cell_info$col[both_filters] <- "orange"
 
-cell_info$col[cell_info$cell_info_second] <- "magenta"
+cell_info$col[cell_info$cell_filter_second] <- "magenta"
 cell_info$col[cell_info$is_doublet] <- "green"
-cell_info$col <- as.factor(cell_info$col)
-levels(cell_info$col) <- c("black", "cyan", "green", "orange", "red", "magenta")
+cell_info$col <- factor(cell_info$col, levels = c("black", "cyan", "green", "orange", "red", "magenta"))
 
 # for manual colour scale
 my_cols <- c("black" = "black",


### PR DESCRIPTION
- Correct error in variable name
- Order factor levels of `cell_info$col` (previous version overwrites them)