### PR TITLE
[FEAT] Add "variousParams" parameter to cellranger_count rule

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -62,6 +62,7 @@ tools:
     local_cores: 12
     mem_mb: 6000
     runtime: 1440
+    variousParams: ""
 
   starsolo:
     call: "STAR "

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -62,6 +62,7 @@ tools:
     local_cores: 12
     mem_mb: 6000
     runtime: 1440
+    variousParams: ""
 
   starsolo:
     call: "STAR "

--- a/workflow/rules/scAmpi_basic_rules.smk
+++ b/workflow/rules/scAmpi_basic_rules.smk
@@ -15,6 +15,7 @@ rule cellranger_count:
         # {sample} needs to be the prefix of all fastq files that belong to this sample.
         # NOTE: no dots are allowed in sample names!
         mySample="{sample}",
+        variousParams=config["tools"]["cellranger_count"]["variousParams"],
     resources:
         mem_mb=config["tools"]["cellranger_count"]["mem_mb"],
         runtime=config["tools"]["cellranger_count"]["runtime"],
@@ -34,6 +35,7 @@ rule cellranger_count:
         "--localcores={params.local_cores} "
         "--fastqs={input.fastqs_dir} "
         "--nosecondary "
+        "{params.variousParams} "
         " 2>&1 | tee ../../{log} ) ; "
         "pwd ; "
         "gunzip {params.cr_out}{params.mySample}/outs/filtered_feature_bc_matrix/features.tsv.gz ; "


### PR DESCRIPTION
To have the possibility to set additional Cellranger parameters, have `variousParams` in rule and config file.
## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Has the appropriate test been performed?

- [x] Feature test has been performed
- [ ] A pipeline test has been performed

## Checklist:
- [ ] CHANGELOG.md is updated.